### PR TITLE
Last commit before we upgrade mainnet from v1.0 to v2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "claims"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "multiversx-sc",
  "multiversx-sc-scenario",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claims"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Ovidiu Damian - Itheum"]
 edition = "2021"
 publish = false

--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ Example with claim type: "harvestClaim@02"
 
 This smart contract, albeit being a simple one, aims to set the standard when it comes to the quality of testing and documentation for which smart contract developers should aim. The above average level of documentation present aims specifically to take advantage of our open source codebase in order to learn, contribute and take good practices from the smart contract.
 
-### Setting up dev environment (project development bootstrap)
+### Setting up dev environment (project development bootstrap) + how to build
 
 - Uses `multiversx-sc-* 0.39.5` SDK libs (see Cargo.toml)
-- Building requires minimum **mxpy 5.2.3** (newer version should also work but devs used 5.2.3). Check version using `mxpy --version`
+- Building requires minimum **mxpy 6.1.1** (newer version should also work but devs used 6.1.1). Check version using `mxpy --version`
 - To build the project, requires minimum Rust version `1.68.0-nightly`. Check your Rust version by running `rustc --version`. To update your Rust, run `rustup update`. To set to nightly run `rustup default nightly` (devs used 1.69.0-nightly)
 - After you make sure you have the minimum Rust version you can then begin development. After you clone repo and before you run build, deploy or run the tests - follow these steps
 
@@ -268,6 +268,45 @@ After using that, to deploy one can simply use:
 ### How to interact
 
 After deployment, one can interact with the smart contract and test its functionality. To do so, one can use the interaction snippets already presented above. More explanations can be found about the snippets inside the devnet.snippets file.
+
+### Mainnet Deployment (via Reproducible Builds)
+- After the security audit has passed the Mainnet deployment need to be verified to match the version that was audited. This guarantee is given via [Reproducible Builds](https://docs.multiversx.com/developers/reproducible-contract-builds/#how-to-run-a-reproducible-build-using-mxpy)
+
+- IMPORTANT - BUT it's important to note that we DID not do a REPRODUCIBLE BUILD for v1.0 deployment. This was only done from v2.0 onwards for the upgraded we did.
+
+**Step 1 (Final build + Code Hash):**
+- Be in the latest `main` branch. On the commit that was audited. Update the cargo.toml files with the correct version. This should match the version we use in our requirements files (i.e Notion). e.g. 1.0.0. you need to update the `cargo.toml` files in the root folder, wasm folder and meta folder.
+
+- In the `cargo.toml` files make sure you set the correct `edition`. i.e. edition = "2021"
+
+- As the `cargo.toml` files has been updated. Build locally as normal. i.e. see "how to build" above and also run tests as per "how to test". This will reflect the `cargo.toml` update in the linked cargo.lock files and produces the final local meta build files to keep the final github check-in and version tagging perfect.
+
+
+**Step 2 (Final build + Code Hash):**
+Once the main commit is locked in, we can then produce the code hash and build to deploy to devnet 1st (for final testing) and then to mainnet (after sending the code hash to the auditor)
+
+1. Make sure your mxpy version is >= 6.
+2. If Cargo.lock is in gitignore, remove it, build the contract and make a new commit. Otherwise this step can be skipped. (see Step 1 and repeat if needed)
+3. Run the following in the root of the repository (run the latest Docker client in your computer. Used `Docker Desktop 4.18.0 (104112) on MacOX 12.6`):
+
+`mxpy contract reproducible-build --docker-image="multiversx/sdk-rust-contract-builder:v4.1.4"`
+
+Note that if you already have a output-docker from a previous build and deploy then delete this folder.
+
+This process may take some time. After it's done you should see "Docker build ran successfully!". An output-docker folder will be created containing the WASM files built in a reproducible way and artifacts.json containing the code hash of the WASM files.
+
+You can then share the auditor the code hash. The auditor will follow the same steps and compare the code hash with yours. If they match, we will be good to go!
+
+Note that "output-docker" folder should not be check-into GIT. 
+
+**Step 4 (Send Code Hash to auditor to verify against devnet and give us all final clear):**
+We should have got this final clear in Step 2, but we still do a final check here.
+
+**Step 5 (Deploy to Devnet as final build for testing + Move ABI to all apps that need it):**
+
+**Step 6 (Tag the commit in the main branch of Github with the version that was deployed. e.g. 1.0.0):**
+
+**Step 6 (Deploy SC to Mainnet):**
 
 ## Contributing
 

--- a/meta/Cargo.lock
+++ b/meta/Cargo.lock
@@ -97,14 +97,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "claims"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "multiversx-sc",
 ]
 
 [[package]]
 name = "claims-meta"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "claims",
  "multiversx-sc",

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claims-meta"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 publish = false
 authors = ["Ovidiu Damian - Itheum"]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -45,14 +45,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "claims"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "multiversx-sc",
 ]
 
 [[package]]
 name = "claims-wasm"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "claims",
  "multiversx-sc-wasm-adapter",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claims-wasm"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 publish = false
 authors = ["Ovidiu Damian - Itheum"]


### PR DESCRIPTION
increment Cargo to have v2.0.0, run local build to gene the cargo.loc…k files, update readne for section on reproducible-build. Last commit before we upgrade mainnet from v1.0 to v2.0